### PR TITLE
SVG Class

### DIFF
--- a/assets/stylesheets/_base.scss
+++ b/assets/stylesheets/_base.scss
@@ -5,8 +5,11 @@ body {
     background: $white;
 }
 .main {
-    img, svg {
+    img {
         max-width: 100%;
+    }
+    .svg {
+        width: 100%;
     }
 }
 .hmpo {


### PR DESCRIPTION
We're embedding our SVGs using `<object>`, only some browsers (notably IE) expose the svg element meaning the current style isn't always applied cross-browser, so use a class instead. Additionally, we always want our SVGs to fill their parent so set the width accordingly.