### PR TITLE
Add build step to copy assets from govuk frontend toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 assets/stylesheets/app.scss
 assets/stylesheets/app.css
+assets/images/icons

--- a/build
+++ b/build
@@ -2,21 +2,48 @@
 
 var path = require('path'),
     fs = require('fs'),
-    mustache = require('mustache');
+    cp = require('child_process'),
+    mustache = require('mustache'),
+    async = require('async');
 
-var src = path.resolve(path.dirname(require.resolve('govuk_frontend_toolkit/package.json')), './stylesheets/');
+var GOVUK_TOOLKIT = path.dirname(require.resolve('govuk_frontend_toolkit/package.json'));
 
-fs.readFile(path.resolve(__dirname, './assets/stylesheets/app.scss.tpl'), function (err, input) {
+function renderTemplate(callback) {
+    var src = path.resolve(GOVUK_TOOLKIT, './stylesheets/');
+
+    fs.readFile(path.resolve(__dirname, './assets/stylesheets/app.scss.tpl'), function (err, input) {
+        if (err) {
+            callback(err);
+        } else {
+            fs.writeFile(path.resolve(__dirname, './assets/stylesheets/app.scss'), mustache.render(input.toString(), { 'govuk-toolkit-path': src }), function (err) {
+                if (err) {
+                    callback(err);
+                } else {
+                    callback();
+                }
+            });
+        }
+    });
+}
+
+function copyImages(callback) {
+    var src = path.resolve(GOVUK_TOOLKIT, './images/');
+
+    fs.mkdir(path.resolve(__dirname, './assets/images/icons'), function (err) {
+        if (err && err.code !== 'EEXIST') {
+            callback(err);
+        } else {
+            cp.exec('cp ' + src + '/* ./assets/images/icons/ -R', callback);
+        }
+    });
+
+}
+
+async.series([
+    renderTemplate,
+    copyImages
+], function (err) {
     if (err) {
-        console.error(err);
-        process.exit(1);
-    } else {
-        fs.writeFile(path.resolve(__dirname, './assets/stylesheets/app.scss'), mustache.render(input.toString(), { 'govuk-toolkit-path': src }), function (err) {
-            if (err) {
-                console.error(err);
-                process.exit(1);
-            }
-        });
+        throw err;
     }
 });
-

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/passports-frontend-toolkit",
   "dependencies": {
+    "async": "^0.9.0",
     "browserify": "^4.0.0",
     "govuk_frontend_toolkit": "^3.1.0",
     "mustache": "^1.1.0",


### PR DESCRIPTION
These assets are referred to in the css files within this project, and so we should ensure we a re able to serve them accordingly.

See also https://collaboration.homeoffice.gov.uk/jirapex/browse/HIT-211, which is partially resolved by this.