### PR TITLE
Remove `min-height` from `#content` styles as this is app specific.

### DIFF
--- a/assets/stylesheets/_layout.scss
+++ b/assets/stylesheets/_layout.scss
@@ -8,10 +8,6 @@
 #content {
     @extend %site-width-container;
     padding-bottom: $gutter;
-    min-height: $site-min-height-small;
-    @include media(tablet) {
-        min-height: $site-min-height;
-    }
     @include media(desktop) {
         padding-bottom: $gutter*3;
     }

--- a/assets/stylesheets/_variables.scss
+++ b/assets/stylesheets/_variables.scss
@@ -1,6 +1,4 @@
 // layout
-$site-min-height-small: 180px;
-$site-min-height: 270px;
 $header-border-width: 10px;
 $header-border: $header-border-width solid $govuk-blue;
 


### PR DESCRIPTION
I will instead apply it to `frontend-static-assets`.