### PR TITLE
Add style support for inline text immediately following a button

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "iojs"
 notifications:
   email: false

--- a/assets/stylesheets/app.scss
+++ b/assets/stylesheets/app.scss
@@ -22,3 +22,4 @@
 // Modules
 @import "modules/validation";
 @import "modules/progressive-reveal";
+@import "modules/buttons";

--- a/assets/stylesheets/govuk-elements/_buttons.scss
+++ b/assets/stylesheets/govuk-elements/_buttons.scss
@@ -45,8 +45,3 @@
     background-image: file-url("icons/icon-pointer-2x.png");
   }
 }
-
-.button + .inline-options {
-    padding-top: em(8);
-    display: inline-block;
-}

--- a/assets/stylesheets/govuk-elements/_buttons.scss
+++ b/assets/stylesheets/govuk-elements/_buttons.scss
@@ -45,3 +45,8 @@
     background-image: file-url("icons/icon-pointer-2x.png");
   }
 }
+
+.button + .inline-options {
+    padding-top: em(8);
+    display: inline-block;
+}

--- a/assets/stylesheets/modules/_buttons.scss
+++ b/assets/stylesheets/modules/_buttons.scss
@@ -1,4 +1,5 @@
 .button + .inline-options {
-    padding-top: em(8);
+    padding-top: em(10);
     display: inline-block;
+    line-height: 1.25;
 }

--- a/assets/stylesheets/modules/_buttons.scss
+++ b/assets/stylesheets/modules/_buttons.scss
@@ -1,0 +1,4 @@
+.button + .inline-options {
+    padding-top: em(8);
+    display: inline-block;
+}


### PR DESCRIPTION
This allows the text to be vertically aligned with the button instead of aligning to the top as previously occured.