### PR TITLE
Prevent a previously shown toggle element being hidden later

### DIFF
--- a/assets/javascript/progressive-reveal.js
+++ b/assets/javascript/progressive-reveal.js
@@ -9,28 +9,21 @@ var helpers = require('./helpers'),
 
 function inputClicked(e, target) {
     target = target || helpers.target(e);
-    var multipleToggle = {};
+    var shown;
     _.each(groups[target.name], function (input) {
         var toggle = document.getElementById(input.getAttribute(toggleAttr));
         if (toggle) {
-            if (multipleToggle[toggle.id] === false) {
-                multipleToggle[toggle.id] = true;
-            } else {
-                multipleToggle[toggle.id] = false;
-            }
 
             if (input.checked) {
                 input.setAttribute('aria-expanded', 'true');
                 toggle.setAttribute('aria-hidden', 'false');
                 helpers.removeClass(toggle, hiddenClass);
+                shown = toggle.id;
             } else {
                 input.setAttribute('aria-expanded', 'false');
-                toggle.setAttribute('aria-hidden', 'true');
-                helpers.addClass(toggle, hiddenClass);
-
-                if (e && target.getAttribute(toggleAttr) === toggle.id && multipleToggle[toggle.id]) {
-                    toggle.setAttribute('aria-hidden', 'false');
-                    helpers.removeClass(toggle, hiddenClass);
+                if (shown !== toggle.id) {
+                    toggle.setAttribute('aria-hidden', 'true');
+                    helpers.addClass(toggle, hiddenClass);
                 }
             }
         }

--- a/test/client/spec/spec.progressive-reveal.js
+++ b/test/client/spec/spec.progressive-reveal.js
@@ -214,6 +214,10 @@ describe('Progressive Reveal', function () {
                     $('#radio3').click();
                     $('#radio1-toggle').hasClass('js-hidden').should.not.be.ok;
                     $('#radio2-toggle').hasClass('js-hidden').should.be.ok;
+
+                    $('#radio1').click();
+                    $('#radio1-toggle').hasClass('js-hidden').should.not.be.ok;
+                    $('#radio2-toggle').hasClass('js-hidden').should.be.ok;
                 });
             });
 


### PR DESCRIPTION
If multiple radio buttons toggle the same progressive reveal target then prevent the later element from hiding the target which has previously been shown.