### PR TITLE
Remove negative margins on grid-row in browser below IE9

### DIFF
--- a/assets/stylesheets/_layout.scss
+++ b/assets/stylesheets/_layout.scss
@@ -91,7 +91,6 @@ $ie8-column-two-thirds: $ie8-column-one-third * 2;
     }
     .grid-row {
         width: $site-width + $gutter;
-        margin: 0 -$gutter-half;
     }
     .column-two-thirds {
         @include ie8-column-two-thirds;


### PR DESCRIPTION
`grid-row` does not need a negative top and bottom margin in IE versions below 9. Remove this mistake.