### PR TITLE
Confine style rules for images and svg files to main content area

### DIFF
--- a/assets/stylesheets/_base.scss
+++ b/assets/stylesheets/_base.scss
@@ -4,7 +4,7 @@ html {
 body {
     background: $white;
 }
-.content {
+.main-content {
     img {
         max-width: 100%;
     }


### PR DESCRIPTION
This PR refines the style rules for any image or svg being given `max-width` of 100% and `width` of 100% respectively to be confined to the newly named `main-content` class.