### PR TITLE
Add indexOf for array if not available.

### DIFF
--- a/assets/javascript/helpers.js
+++ b/assets/javascript/helpers.js
@@ -6,6 +6,15 @@ var DESKTOP_WIDTH = 769;
 
 var helpers = {};
 
+if (!Array.prototype.indexOf) {
+    Array.prototype.indexOf = function (obj, start) {
+        for (var i = (start || 0), j = this.length; i < j; i++) {
+            if (this[i] === obj) { return i; }
+        }
+        return -1;
+    };
+}
+
 helpers.documentReady = function (callback) {
     this.addEvent(document, 'DOMContentLoaded', callback);
     this.addEvent(window, 'load', callback);


### PR DESCRIPTION
IE8 will throw an error if you try and use [].indexOf

This polyfill will add indexOf if it's not available on the prototype.