### PR TITLE
Hide {id}-panel element by default if present, fall back to …

### DIFF
--- a/assets/javascript/progressive-reveal.js
+++ b/assets/javascript/progressive-reveal.js
@@ -11,9 +11,12 @@ function inputClicked(e, target) {
     target = target || helpers.target(e);
     var shown;
     _.each(groups[target.name], function (input) {
-        var toggle = document.getElementById(input.getAttribute(toggleAttr));
+        var id = input.getAttribute(toggleAttr)
+        // check if the element supplied is part of an {id}-panel
+        // if so then toggle this parent element to also toggle
+        // associated labels and legends
+        var toggle = document.getElementById(id + '-panel') || document.getElementById(id);
         if (toggle) {
-
             if (input.checked) {
                 input.setAttribute('aria-expanded', 'true');
                 toggle.setAttribute('aria-hidden', 'false');

--- a/test/client/spec/spec.progressive-reveal.js
+++ b/test/client/spec/spec.progressive-reveal.js
@@ -36,6 +36,25 @@ describe('Progressive Reveal', function () {
 
         });
 
+        describe('parent panel', function () {
+
+            beforeEach(function () {
+                $('form').append('<div id="check-toggle-panel" class="reveal js-hidden">');
+                $('label').append('<input type="checkbox" id="check" name="check" data-toggle="check-toggle">CheckBox');
+                progressiveReveal();
+            });
+
+            it('should show #check-toggle-panel if present', function () {
+                $('#check').click();
+                $('#check-toggle-panel').hasClass('js-hidden').should.not.be.ok;
+            });
+
+            it('should not show #show-toggle', function () {
+                $('#check').click();
+                $('#check-toggle').hasClass('js-hidden').should.be.ok;
+            });
+        });
+
         describe('pre-selected', function () {
 
             beforeEach(function () {


### PR DESCRIPTION
…hide by id

* Look for a parent group element (#example-group) to target, fall back to #example if not present
* This means a form element key can be passed and it will be hidden along with all labels