### PR TITLE
Limit version of GOVUK Elements dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/UKHomeOffice/passports-frontend-toolkit",
   "dependencies": {
     "browserify": "^13.0.1",
-    "govuk-elements-sass": "^2.0.0",
+    "govuk-elements-sass": "~2.1.0",
     "govuk_frontend_toolkit": "^4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Limit govuk-elements-sass to patch versions of v2.1 until we want to use the new radio and check button styling (released in v2.2).